### PR TITLE
Remove ndarray-linalg from main dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ categories = ["mathematics", "science"]
 
 [dependencies]
 ndarray = "^0.15"
-ndarray-linalg = "^0.16"
 num-traits = "^0.2"
 num = "^0.4"
 easyfft = "^0.2"
+
+[dev-dependencies]
+ndarray-linalg = "^0.16"


### PR DESCRIPTION
I found out that `ndarray-linalg` is only used in the tests, and since it is posing some trouble in my dependency tree (it doesn't work out of the box on Windows and MacOS), I believe it is much nicer  to move it to the `dev-dependencies`. 